### PR TITLE
Fix scaling issues

### DIFF
--- a/living_hinge.py
+++ b/living_hinge.py
@@ -471,10 +471,10 @@ class LivingHingeEffect(inkex.EffectExtension):
             for elem in self.svg.selected.values():
                 # Determine width and height based on the selected object's bounding box.
                 bbox = elem.bounding_box()
-                self.options.width = bbox.width
-                self.options.height = bbox.height
-                x = bbox.x.minimum
-                y = bbox.y.minimum
+                self.options.width = self.svg.unittouu(bbox.width)
+                self.options.height = self.svg.unittouu(bbox.height)
+                x = self.svg.unittouu(bbox.x.minimum)
+                y = self.svg.unittouu(bbox.y.minimum)
                 draw_one(x, y)
 
 


### PR DESCRIPTION
When using the extension on selected options it was detecting their bounding at the wrong scale.  Just needed to add unittouu to a few places to fix.  Seems to be working as intended with these changes.